### PR TITLE
feat: support building via Docker on aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM ghcr.io/void-linux/void-glibc:20250401r1
+FROM ghcr.io/void-linux/void-glibc:20250801R1
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-RUN echo "repository=https://mirrors.servercentral.com/voidlinux/current" > /etc/xbps.d/00-repository-main.conf
+# https://docs.voidlinux.org/xbps/repositories/mirrors/changing.html
+RUN mkdir -p /etc/xbps.d && \
+    cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/ && \
+    sed -i 's|https://repo-default.voidlinux.org|https://mirrors.servercentral.com/voidlinux|g' /etc/xbps.d/*-repository-*.conf
 
 RUN xbps-install -Suy xbps
+
 RUN xbps-install -uy bash curl dosfstools e2fsprogs findutils util-linux gzip \
-    git m4 mtools pigz tar zstd xz zip mkpasswd zip unzip prelink just rsync \
-    autoconf automake libtool pkg-config make gcc confuse-devel openssl
+    git m4 mtools pigz tar zstd xz zip mkpasswd zip unzip just rsync \
+    autoconf automake libtool pkg-config make gcc confuse-devel openssl patchelf
 
 RUN curl -L https://github.com/pengutronix/genimage/archive/refs/tags/v18.tar.gz | tar --use-compress-program=pigz -x -C /tmp \
     && cd /tmp/genimage-18 \

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ set -e
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Static config
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-REQUIRED_CMDS=(curl zip unzip genimage m4 xbps-install mkpasswd execstack)
+REQUIRED_CMDS=(curl zip unzip genimage m4 xbps-install mkpasswd patchelf)
 for cmd in "${REQUIRED_CMDS[@]}"; do
   if ! command -v "$cmd" > /dev/null 2>&1; then
     echo "$cmd is required to run this script."

--- a/scripts/stages/00/50-stock-files.sh
+++ b/scripts/stages/00/50-stock-files.sh
@@ -32,4 +32,5 @@ ln -sf libfontconfig.so.1.12.0 "$ROOTFS_PATH"/usr/lib/libfontconfig.so.1
 ln -sf libfreetype.so.6.16.1 "$ROOTFS_PATH"/usr/lib/libfreetype.so.6
 ln -sf libpng16.so.16.36.0 "$ROOTFS_PATH"/usr/lib/libpng16.so.16
 
-execstack -c "$ROOTFS_PATH"/usr/lib/libMali.so
+# Use patchelf to clear executable stack flag (equivalent to execstack -c)
+patchelf --clear-execstack "$ROOTFS_PATH"/usr/lib/libMali.so


### PR DESCRIPTION
Title. Wanted to get the latest 3.0 beta and ran into some hiccups while building due to `prelink`-package missing on aarch64 on Void repositories. Fix for this was to use `patchelf` instead of `execstack` for clearing stack flag.
This also updates the docker image to `latest` void-linux glibc image.

At least tested to be working on my Car Thing with building done inside Ubuntu VM on an M1 Mac. Although terbium.app had a weird quirk where the zip install did not work for some reason, but "restore folder" option worked.
